### PR TITLE
Ignore cancelled events for compatibility with protection plugins

### DIFF
--- a/src/main/kotlin/xyz/atrius/waystones/event/DestroyEvent.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/event/DestroyEvent.kt
@@ -11,17 +11,17 @@ import xyz.atrius.waystones.service.WarpNameService
 
 object DestroyEvent : Listener {
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     fun onBreak(event: BlockBreakEvent) {
         val block = event.block
         if (block.type == Material.LODESTONE)
             WarpNameService.remove(block.location)
     }
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     fun onExplode(event: BlockExplodeEvent) = destroy(event.blockList())
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     fun onEntityExplode(event: EntityExplodeEvent) = destroy(event.blockList())
 
     private fun destroy(blocks: List<Block>) =

--- a/src/main/kotlin/xyz/atrius/waystones/event/DestroyEvent.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/event/DestroyEvent.kt
@@ -3,6 +3,7 @@ package xyz.atrius.waystones.event
 import org.bukkit.Material
 import org.bukkit.block.Block
 import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
 import org.bukkit.event.Listener
 import org.bukkit.event.block.BlockBreakEvent
 import org.bukkit.event.block.BlockExplodeEvent
@@ -11,17 +12,17 @@ import xyz.atrius.waystones.service.WarpNameService
 
 object DestroyEvent : Listener {
 
-    @EventHandler(ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     fun onBreak(event: BlockBreakEvent) {
         val block = event.block
         if (block.type == Material.LODESTONE)
             WarpNameService.remove(block.location)
     }
 
-    @EventHandler(ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     fun onExplode(event: BlockExplodeEvent) = destroy(event.blockList())
 
-    @EventHandler(ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     fun onEntityExplode(event: EntityExplodeEvent) = destroy(event.blockList())
 
     private fun destroy(blocks: List<Block>) =

--- a/src/main/kotlin/xyz/atrius/waystones/event/InfoEvent.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/event/InfoEvent.kt
@@ -15,7 +15,7 @@ import xyz.atrius.waystones.utility.sendActionMessage
 
 object InfoEvent: Listener {
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     fun onClick(event: PlayerInteractEvent) {
         // Filter non left-click events
         if (event.action != Action.LEFT_CLICK_BLOCK)

--- a/src/main/kotlin/xyz/atrius/waystones/event/LinkEvent.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/event/LinkEvent.kt
@@ -12,7 +12,7 @@ import xyz.atrius.waystones.utility.sendActionError
 
 object LinkEvent : Listener {
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     fun onSet(event: PlayerInteractEvent) {
         if (event.action != Action.RIGHT_CLICK_BLOCK)
             return

--- a/src/main/kotlin/xyz/atrius/waystones/event/NameEvent.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/event/NameEvent.kt
@@ -13,7 +13,7 @@ import xyz.atrius.waystones.utility.sendActionMessage
 
 object NameEvent : Listener {
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     fun onClick(event: PlayerInteractEvent) {
         if (event.action != RIGHT_CLICK_BLOCK)
             return

--- a/src/main/kotlin/xyz/atrius/waystones/event/WarpEvent.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/event/WarpEvent.kt
@@ -23,7 +23,7 @@ import xyz.atrius.waystones.utility.sendActionMessage
 
 object WarpEvent : Listener {
 
-    @EventHandler(ignoreCancelled = true)
+    @EventHandler
     fun onClick(event: PlayerInteractEvent) {
         val player = event.player
         // Don't start warp while flying with elytra, not right-clicking, or a lodestone was clicked

--- a/src/main/kotlin/xyz/atrius/waystones/event/WarpEvent.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/event/WarpEvent.kt
@@ -23,7 +23,7 @@ import xyz.atrius.waystones.utility.sendActionMessage
 
 object WarpEvent : Listener {
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     fun onClick(event: PlayerInteractEvent) {
         val player = event.player
         // Don't start warp while flying with elytra, not right-clicking, or a lodestone was clicked
@@ -55,7 +55,7 @@ object WarpEvent : Listener {
         }
     }
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     fun onMove(event: PlayerMoveEvent) {
         if (!event.hasMovedBlock())
             return
@@ -66,7 +66,7 @@ object WarpEvent : Listener {
         player.sendActionError("Teleportation cancelled")
     }
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     fun onDamage(event: EntityDamageEvent) {
         val entity = event.entity
         if (!configuration.damageStopsWarping() || entity !is Player)

--- a/src/main/kotlin/xyz/atrius/waystones/event/WarpEvent.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/event/WarpEvent.kt
@@ -4,6 +4,7 @@ import net.md_5.bungee.api.ChatColor
 import org.bukkit.Material
 import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
 import org.bukkit.event.Listener
 import org.bukkit.event.block.Action.RIGHT_CLICK_AIR
 import org.bukkit.event.entity.EntityDamageEvent
@@ -55,7 +56,7 @@ object WarpEvent : Listener {
         }
     }
 
-    @EventHandler(ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     fun onMove(event: PlayerMoveEvent) {
         if (!event.hasMovedBlock())
             return
@@ -66,7 +67,7 @@ object WarpEvent : Listener {
         player.sendActionError("Teleportation cancelled")
     }
 
-    @EventHandler(ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     fun onDamage(event: EntityDamageEvent) {
         val entity = event.entity
         if (!configuration.damageStopsWarping() || entity !is Player)


### PR DESCRIPTION
Make event listeners ignore events already cancelled by other plugins. (e.g. protection plugins like Residence or griefprevention)