### PR TITLE
Fix JSON saving does not truncate the old file

### DIFF
--- a/src/main/kotlin/xyz/atrius/waystones/data/JsonFile.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/data/JsonFile.kt
@@ -25,6 +25,6 @@ open class JsonFile<T>(name: String) {
 
     fun save() {
         val json = json.toJson(data)
-        Files.write(file.toPath(), json.toByteArray(), CREATE, WRITE)
+        Files.write(file.toPath(), json.toByteArray())
     }
 }


### PR DESCRIPTION
Fix saving broken JSON files if the new content is shorter than the older files.