### PR TITLE
Add dynamic key recipe to configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Players can create and warp to a waystone by creating a lodestone and linking it
 - **portal-sickness-damage *[default: 5.0]***: The amount of damage (in heart pieces) taken by the user if warping while sick and DAMAGE_ON_TELEPORT is set.
 - **relinkable-keys *[default: true]***: Whether or not warp keys can be relinked after they are linked to a waystone.
 - **enable-key-items *[default: true]***: Whether or not to use a custom item for warp keys. This enables a custom crafting recipe for the item, and prevents normal compasses from being used as warp keys. If this setting is enabled later, compass warp keys *should* hopefully still work as warp keys.
+- **key-recipe *[default: shown above]***: The crafting recipe used for custom key items if custom keys are enabled. 
 
 ### Commands
 - **/waystones**: Provides info about the plugin

--- a/src/main/kotlin/xyz/atrius/waystones/data/Property.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/data/Property.kt
@@ -28,7 +28,7 @@ class Property<T>(
 
     operator fun invoke(): T = value
 
-    operator fun invoke(input: String?): Boolean {
+    operator fun invoke(input: Any?): Boolean {
         value = parser.parse(input) ?: return false
         onUpdate()
         return true
@@ -39,10 +39,7 @@ class Property<T>(
     }
 
     private fun <T> update(property: String, new: T) {
-        if (new is List<*>)
-            config.set(property, new)
-        else
-            config.set(property, new.toString())
+        config.set(property, new)
         plugin.saveConfig()
     }
 

--- a/src/main/kotlin/xyz/atrius/waystones/data/Property.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/data/Property.kt
@@ -17,7 +17,7 @@ class Property<T>(
         get() = plugin.config
 
     private var value: T by observable(
-        parser.parse(config.getString(property))
+        parser.parse(config.get(property))
             ?: default.also { update(property, it) },
         observe(property)
     )
@@ -39,7 +39,10 @@ class Property<T>(
     }
 
     private fun <T> update(property: String, new: T) {
-        config.set(property, new.toString())
+        if (new is List<*>)
+            config.set(property, new)
+        else
+            config.set(property, new.toString())
         plugin.saveConfig()
     }
 

--- a/src/main/kotlin/xyz/atrius/waystones/data/Property.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/data/Property.kt
@@ -4,6 +4,7 @@ import org.bukkit.configuration.file.FileConfiguration
 import xyz.atrius.waystones.data.config.ArgumentParser
 import xyz.atrius.waystones.data.config.ConfigManager
 import xyz.atrius.waystones.plugin
+import java.util.*
 import kotlin.properties.Delegates.observable
 import kotlin.reflect.KProperty
 
@@ -39,7 +40,11 @@ class Property<T>(
     }
 
     private fun <T> update(property: String, new: T) {
-        config.set(property, new)
+        config.set(property, when (new) {
+            is Enum<*> -> new.name
+            is Locale -> new.toString()
+            else -> new
+        })
         plugin.saveConfig()
     }
 

--- a/src/main/kotlin/xyz/atrius/waystones/data/config/Config.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/data/config/Config.kt
@@ -90,6 +90,11 @@ class Config(plugin: KotlinPlugin) {
     val keyItems: Property<Boolean> =
         Property("enable-key-items", true, BooleanParser)
 
+    val keyRecipe: Property<List<String>> =
+        Property("key-recipe", listOf(
+            "", "IRON_INGOT", "", "IRON_INGOT", "REDSTONE_BLOCK", "IRON_INGOT", "", "IRON_INGOT", ""
+        ), ListParser(StringParser))
+
     // Netherite grants the max amount of boost per block
     fun netheriteBoost(): Int = maxBoost()
 

--- a/src/main/kotlin/xyz/atrius/waystones/data/config/Config.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/data/config/Config.kt
@@ -92,7 +92,9 @@ class Config(plugin: KotlinPlugin) {
 
     val keyRecipe: Property<List<String>> =
         Property("key-recipe", listOf(
-            "", "IRON_INGOT", "", "IRON_INGOT", "REDSTONE_BLOCK", "IRON_INGOT", "", "IRON_INGOT", ""
+            "AIR", "IRON_INGOT", "AIR",
+            "IRON_INGOT", "REDSTONE_BLOCK", "IRON_INGOT",
+            "AIR", "IRON_INGOT", "AIR"
         ), ListParser(StringParser))
 
     // Netherite grants the max amount of boost per block

--- a/src/main/kotlin/xyz/atrius/waystones/data/config/ConfigManager.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/data/config/ConfigManager.kt
@@ -28,7 +28,7 @@ object ConfigManager {
     fun reload() {
         plugin.reloadConfig()
         for ((prop, option) in options) {
-            option(plugin.config.getString(prop))
+            option(plugin.config.get(prop))
         }
     }
 }

--- a/src/main/kotlin/xyz/atrius/waystones/data/crafting/CompassRecipe.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/data/crafting/CompassRecipe.kt
@@ -1,19 +1,26 @@
 package xyz.atrius.waystones.data.crafting
 
 import org.bukkit.Material
+import xyz.atrius.waystones.configuration
 import xyz.atrius.waystones.utility.defaultWarpKey
 import xyz.atrius.waystones.utility.toKey
+import kotlin.math.sqrt
 
 object CompassRecipe : CraftingRecipe("is_warp_key".toKey(), defaultWarpKey()) {
 
-    override val recipe = """
-        | * 
-        |*x*
-        | * 
-    """.trimMargin()
+    override val recipe = run {
+        // Pull recipe from config and determine grid size (list can be size 1, 4, or 9)
+        val recipe = configuration.keyRecipe()
+        val size = sqrt(recipe.size.toFloat()).toInt()
+        // Map each item to a hashcode and join them into a multiline string
+        recipe.map { it.hashCode() }
+            .chunked(size).joinToString("\n") { it.joinToString("") }
+    }
 
-    override val items = hashMapOf(
-        '*' to Material.IRON_INGOT,
-        'x' to Material.REDSTONE_BLOCK
-    )
+    override val items = hashMapOf<Char, Material>().apply {
+        // For each item in the recipe, map it's material to it's hashcode
+        for (item in configuration.keyRecipe().toHashSet())
+            this[item.hashCode().toChar()] =
+                if (item.isEmpty()) Material.AIR else Material.valueOf(item)
+    }
 }

--- a/src/main/kotlin/xyz/atrius/waystones/data/crafting/CompassRecipe.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/data/crafting/CompassRecipe.kt
@@ -22,7 +22,7 @@ object CompassRecipe : CraftingRecipe("is_warp_key".toKey(), defaultWarpKey()) {
 
     override val items = hashMapOf<Char, Material>().apply {
         // For each item in the recipe, map it's material to it's hashcode
-        for (item in keyRecipe.toHashSet()) this[item.hashChar()] =
-            if (item.isEmpty()) Material.AIR else Material.valueOf(item) // Empty items default to air
+        for (item in keyRecipe.toHashSet())
+            this[item.hashChar()] = Material.valueOf(item)
     }
 }

--- a/src/main/kotlin/xyz/atrius/waystones/data/crafting/CompassRecipe.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/data/crafting/CompassRecipe.kt
@@ -13,7 +13,7 @@ object CompassRecipe : CraftingRecipe("is_warp_key".toKey(), defaultWarpKey()) {
         val recipe = configuration.keyRecipe()
         val size = sqrt(recipe.size.toFloat()).toInt()
         // Map each item to a hashcode and join them into a multiline string
-        recipe.map { it.hashCode() }
+        recipe.map { it.hashCode().toChar() }
             .chunked(size).joinToString("\n") { it.joinToString("") }
     }
 

--- a/src/main/kotlin/xyz/atrius/waystones/data/crafting/CompassRecipe.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/data/crafting/CompassRecipe.kt
@@ -2,25 +2,27 @@ package xyz.atrius.waystones.data.crafting
 
 import org.bukkit.Material
 import xyz.atrius.waystones.configuration
-import xyz.atrius.waystones.utility.defaultWarpKey
-import xyz.atrius.waystones.utility.toKey
-import kotlin.math.sqrt
+import xyz.atrius.waystones.utility.*
 
 object CompassRecipe : CraftingRecipe("is_warp_key".toKey(), defaultWarpKey()) {
 
+    private val keyRecipe = configuration.keyRecipe()
+
     override val recipe = run {
         // Pull recipe from config and determine grid size (list can be size 1, 4, or 9)
-        val recipe = configuration.keyRecipe()
-        val size = sqrt(recipe.size.toFloat()).toInt()
-        // Map each item to a hashcode and join them into a multiline string
-        recipe.map { it.hashCode().toChar() }
-            .chunked(size).joinToString("\n") { it.joinToString("") }
+        val size = sqrt(keyRecipe.size)
+        keyRecipe
+            // Map each item to it's hash char
+            .map(String::hashChar)
+            // Chunk the list by its square size
+            .chunked(size)
+            // Glue each list into a string and join each by a newline
+            .joinToString("\n", transform = List<Char>::glue)
     }
 
     override val items = hashMapOf<Char, Material>().apply {
         // For each item in the recipe, map it's material to it's hashcode
-        for (item in configuration.keyRecipe().toHashSet())
-            this[item.hashCode().toChar()] =
-                if (item.isEmpty()) Material.AIR else Material.valueOf(item)
+        for (item in keyRecipe.toHashSet()) this[item.hashChar()] =
+            if (item.isEmpty()) Material.AIR else Material.valueOf(item) // Empty items default to air
     }
 }

--- a/src/main/kotlin/xyz/atrius/waystones/utility/Data.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/utility/Data.kt
@@ -4,7 +4,6 @@ import org.bukkit.block.Block
 import org.bukkit.block.data.BlockData
 import org.bukkit.inventory.ItemStack
 import org.bukkit.inventory.meta.ItemMeta
-import xyz.atrius.waystones.plugin
 
 inline fun <reified T : BlockData> Block.update(scope: T.() -> Unit) = also {
     val data = this.blockData as T

--- a/src/main/kotlin/xyz/atrius/waystones/utility/Number.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/utility/Number.kt
@@ -1,0 +1,11 @@
+package xyz.atrius.waystones.utility
+
+import kotlin.math.sqrt as ktSqrt
+
+// Helper function since kotlin doesn't have a native fixed-point square root
+fun sqrt(value: Int): Int =
+    ktSqrt(value.toFloat()).toInt()
+
+// Calculates the character representation of an object based on its hashcode
+fun Any.hashChar(): Char =
+    hashCode().toChar()

--- a/src/main/kotlin/xyz/atrius/waystones/utility/String.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/utility/String.kt
@@ -13,3 +13,6 @@ fun String.toKey() = NamespacedKey(plugin, this)
 // Split a multiline string into a spreadable array
 fun String.splitMultiline() =
     split("\n").toTypedArray()
+
+// Glues a list together into a single string
+fun <T> List<T>.glue(): String = joinToString("")

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -17,3 +17,13 @@ portal-sickness-warping: DAMAGE_ON_TELEPORT
 portal-sickness-damage: 5.0
 relinkable-keys: true
 enable-key-items: true
+key-recipe:
+  - ""
+  - "IRON_INGOT"
+  - ""
+  - "IRON_INGOT"
+  - "REDSTONE_BLOCK"
+  - "IRON_INGOT"
+  - ""
+  - "IRON_INGOT"
+  - ""

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -18,12 +18,12 @@ portal-sickness-damage: 5.0
 relinkable-keys: true
 enable-key-items: true
 key-recipe:
-  - ""
-  - "IRON_INGOT"
-  - ""
-  - "IRON_INGOT"
-  - "REDSTONE_BLOCK"
-  - "IRON_INGOT"
-  - ""
-  - "IRON_INGOT"
-  - ""
+  - ''
+  - IRON_INGOT
+  - ''
+  - IRON_INGOT
+  - REDSTONE_BLOCK
+  - IRON_INGOT
+  - ''
+  - IRON_INGOT
+  - ''

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -18,12 +18,12 @@ portal-sickness-damage: 5.0
 relinkable-keys: true
 enable-key-items: true
 key-recipe:
-  - ''
+  - AIR
   - IRON_INGOT
-  - ''
+  - AIR
   - IRON_INGOT
   - REDSTONE_BLOCK
   - IRON_INGOT
-  - ''
+  - AIR
   - IRON_INGOT
-  - ''
+  - AIR


### PR DESCRIPTION
This PR adds the ability to determine a custom crafting recipe for warp keys as requested by #26. Crafting recipes are defined by the `key-recipe` property in the configuration file in the format of `[ "item1", "item2", "item3" ]`. Acceptable lengths for this list are 1, 4, or 9 (corresponding to the squares of 1, 2, and 3). Each item in this list should correspond to the name of a value in the  `Material` enum.

Testing was done locally and it appears to function, however further testing should be done to make sure it behaves properly and as expected.