### PR TITLE
Changes to the Java Random Implementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '6.0.0'
 }
 
-String pluginVersion = '1.1.0'
+String pluginVersion = '1.1.1'
 
 repositories {
     mavenCentral()
@@ -15,7 +15,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly 'org.spigotmc:spigot-api:1.18-pre8-R0.1-SNAPSHOT'
+    compileOnly 'org.spigotmc:spigot-api:1.19.2-R0.1-SNAPSHOT'
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.0'
 }
 

--- a/src/main/kotlin/xyz/atrius/waystones/handler/WaystoneHandler.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/handler/WaystoneHandler.kt
@@ -22,7 +22,7 @@ import xyz.atrius.waystones.handler.HandleState.Fail
 import xyz.atrius.waystones.handler.HandleState.Success
 import xyz.atrius.waystones.localization
 import xyz.atrius.waystones.utility.*
-import kotlin.random.Random
+import java.util.Random
 
 class WaystoneHandler(
     override val player: Player,
@@ -68,7 +68,7 @@ class WaystoneHandler(
             player.damage(configuration.portalSicknessDamage())
         // Give portal sickness to the player if they aren't immortal, are unlucky, or already are sick
         if (configuration.portalSickness()
-            && (sick || Random.nextDouble() < configuration.portalSicknessChance())
+            && (sick || Random().nextDouble() < configuration.portalSicknessChance())
             && !block.hasInfinitePower()
         ) {
             player.addPotionEffects(

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: Waystones
-version: 1.1.0-1.16.5
+version: 1.1.0-1.19.2
 main: xyz.atrius.waystones.Waystones
-api-version: 1.18
+api-version: 1.19
 prefix: Waystones
 authors: [Atrius, Sepshun, NewbieOrange]
 description: Warp stones for survival


### PR DESCRIPTION
This uses the java random implementation instead of the kotlin one. The Plugin is now useable with Minecraft Spigot/Paper 1.19.2

The Error before: https://gist.github.com/PhilippCl/4209b1cfd6ba600ad86fd47ad565a059