### PR TITLE
ci: Introduce workflows for publishing the plugin to Hangar

### DIFF
--- a/.github/workflows/pr-pipeline.yml
+++ b/.github/workflows/pr-pipeline.yml
@@ -7,7 +7,10 @@ on:
       - 'src/test/kotlin/**'
       - 'src/main/resources/**'
       - 'src/test/resources/**'
+      - 'build.gradle.kts'
+      - 'gradle.properties'
       - '.github/workflows/pr-pipeline.yml'
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-hangar-release.yml
+++ b/.github/workflows/publish-hangar-release.yml
@@ -1,0 +1,22 @@
+name: Publish Plugin Release to Hangar
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  publish-snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Validate Gradle
+        uses: gradle/actions/wrapper-validation@v4
+      - name: Change Wrapper Permissions
+        run: chmod +x ./gradlew
+      - name: Publish Snapshot
+        env:
+          HANGAR_API_TOKEN: ${{ secrets.HANGAR_API_TOKEN }}
+        run: ./gradlew build publishWaystonesReleasePublicationToHangar --stacktrace

--- a/.github/workflows/publish-hangar-snapshot.yml
+++ b/.github/workflows/publish-hangar-snapshot.yml
@@ -1,0 +1,22 @@
+name: Publish Plugin Snapshot to Hangar
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  publish-snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Validate Gradle
+        uses: gradle/actions/wrapper-validation@v4
+      - name: Change Wrapper Permissions
+        run: chmod +x ./gradlew
+      - name: Publish Snapshot
+        env:
+          HANGAR_API_TOKEN: ${{ secrets.HANGAR_API_TOKEN }}
+        run: ./gradlew build publishWaystonesSnapshotPublicationToHangar --stacktrace

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,19 @@
+name: Generate Release PR
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          release-type: go
+          include-v-in-tag: false

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,4 @@
+version=2.0.0
+buildPaperVersion=1.21.8
+pluginApiVersion=1.21
+paperVersions=1.21.8

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -1,7 +1,7 @@
 name: Waystones
-version: 2.0.1-1.21.7
+version: ${version}
 main: xyz.atrius.waystones.Waystones
-api-version: '1.21'
+api-version: ${apiVersion}
 prefix: Waystones
 authors: [Atri, Sepshun, NewbieOrange]
 description: Warp stones for survival


### PR DESCRIPTION
This commit adds support for publishing Waystones to Hangar on its Release and Snapshot channels. Snapshots should auto-deploy on merge with this repo's main/master branch, and a release should be generated after the corresponding release-please branch is merged in, or the release workflow is dispatched.