### PR TITLE
fix: Fix background texture for Waystones advancement window

### DIFF
--- a/src/main/kotlin/xyz/atrius/waystones/data/json/advancement/Display.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/data/json/advancement/Display.kt
@@ -8,5 +8,5 @@ data class Display(
     val announceToChat: Boolean = true,
     val hidden: Boolean = false,
     val frame: AdvancementType? = null,
-    val background: String = "minecraft:textures/block/lodestone_top.png",
+    val background: String = "minecraft:block/lodestone_top",
 )


### PR DESCRIPTION
This appears to have broken in recent versions of the game, changing the background data seems to fix this.