### PR TITLE
build: Add git hash to snapshot versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -119,7 +119,14 @@ hangarPublish {
     }
 
     publications.register("WaystonesSnapshot") {
-        version = "$pluginVersion-SNAPSHOT"
+        val gitHash = providers
+            .exec { commandLine("git", "rev-parse", "--short", "HEAD") }
+            .standardOutput
+            .asText
+            .map { it.trim() }
+            .orElse("")
+
+        version = "$pluginVersion-SNAPSHOT+$gitHash"
         id = "waystones"
         channel = "Snapshot"
         apiKey = System.getenv("HANGAR_API_TOKEN")


### PR DESCRIPTION
This should help avoid the issues with duplicate version tags in hangar, causing our pipelines to break.