### PR TITLE
chore: Minimize plugin shadowing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,10 +4,10 @@ import io.papermc.hangarpublishplugin.internal.util.capitalized
 plugins {
     id("java")
     id("idea")
-    id("org.jetbrains.kotlin.jvm") version "2.1.21"
+    id("org.jetbrains.kotlin.jvm") version "2.2.0"
     id("com.gradleup.shadow") version "8.3.6"
     id("dev.s7a.gradle.minecraft.server") version "3.2.1"
-    id("com.google.devtools.ksp") version "2.1.21-2.0.1"
+    id("com.google.devtools.ksp") version "2.2.0-2.0.2"
     id("io.gitlab.arturbosch.detekt") version "1.23.8"
     id("io.papermc.hangar-publish-plugin") version "0.1.3"
     id("com.modrinth.minotaur") version "2.8.7"
@@ -29,7 +29,7 @@ java {
 
 dependencies {
     compileOnly("io.papermc.paper:paper-api:$buildPaperVersion-R0.1-SNAPSHOT")
-    implementation("org.jetbrains.kotlin:kotlin-stdlib:2.1.21")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib:2.2.0")
     implementation("io.insert-koin:koin-core:4.1.0-RC1")
     implementation("io.arrow-kt:arrow-core:2.1.2")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,6 @@ plugins {
 }
 
 val buildPaperVersion: String by project
-val pluginApiVersion: String by project
 val paperVersions: String by project
 
 repositories {
@@ -53,6 +52,13 @@ tasks.shadowJar {
     minimize()
     archiveClassifier.set("")
     archiveVersion.set(pluginVersion)
+
+    relocate("kotlin", "xyz.atrius.waystones.kotlin")
+
+    dependencies {
+        exclude(dependency("io.insert-koin:koin-core"))
+        exclude(dependency("io.arrow-kt:arrow-core"))
+    }
 }
 
 tasks.withType<Test>().configureEach {
@@ -61,10 +67,7 @@ tasks.withType<Test>().configureEach {
 
 tasks.processResources {
     filesMatching("paper-plugin.yml") {
-        expand(
-            "version" to version,
-            "apiVersion" to pluginApiVersion,
-        )
+        expand(project.properties)
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -117,19 +117,11 @@ val supported = paperVersions
     .map { it.trim() }
 
 hangarPublish {
-    val repo = System.getenv("GITHUB_REPOSITORY")
-
     publications.register("WaystonesRelease") {
         version = pluginVersion
         id = "waystones"
         channel = "Release"
-        changelog = """
-            |# ${project.name.capitalized()} Release version ${version.get()}
-            |This version is built for ${buildPaperVersion}!
-            |
-            |See the full changelog on [GitHub](https://github.com/$repo/releases/tag/v${version.get()})
-        """.trimMargin()
-
+        changelog = file("CHANGELOG.md").readText()
         apiKey = System.getenv("HANGAR_API_TOKEN")
 
         platforms {
@@ -144,13 +136,7 @@ hangarPublish {
         version = "$pluginVersion-SNAPSHOT+$gitHash"
         id = "waystones"
         channel = "Snapshot"
-        changelog = """
-            |# ${project.name.capitalized()} Dev Snapshot $gitHash
-            |This version is built for ${buildPaperVersion}!
-            |
-            |Check [Github](https://github.com/$repo/commits) for full commit history!
-        """.trimMargin()
-
+        changelog = "${project.name.capitalized()} Dev Snapshot [$gitHash]"
         apiKey = System.getenv("HANGAR_API_TOKEN")
 
         platforms {
@@ -175,7 +161,7 @@ modrinth {
 
         else -> {
             versionNumber = "$pluginVersion-SNAPSHOT+$gitHash"
-            changelog = "${project.name.capitalized()} Dev Snapshot $gitHash"
+            changelog = "${project.name.capitalized()} Dev Snapshot [$gitHash]"
         }
     }
     // Common values

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,4 @@ version=2.0.0
 buildPaperVersion=1.21.8
 pluginApiVersion=1.21
 paperVersions=1.21.8
+pluginWebsite=https://github.com/AtriusX/Waystones

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -1,10 +1,14 @@
 name: Waystones
 version: ${version}
 main: xyz.atrius.waystones.Waystones
-api-version: ${apiVersion}
+api-version: ${pluginApiVersion}
 prefix: Waystones
+website: ${pluginWebsite}
 authors: [Atri, Sepshun, NewbieOrange]
 description: Warp stones for survival
+libraries:
+  - io.insert-koin:koin-core:4.1.0-RC1
+  - io.arrow-kt:arrow-core:2.1.2
 commands:
   ws:
     description: Displays plugin info and usage


### PR DESCRIPTION
This removes Koin and Arrow from the list of shadowed dependencies, and instead sandboxes them using Paper's libraries feature. The Kotlin standard library is also relocated to the plugin namespace to minimize the risk of secondary plugin conflicts.

While this approach is not ideal, it is the best option we have until better tooling exists for testing plugins with dependencies on other plugins.