### PR TITLE
build: Revert to Gradle 8.14.3, disable caching for deployments

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import dev.s7a.gradle.minecraft.server.tasks.LaunchMinecraftServerTask
+import io.papermc.hangarpublishplugin.HangarPublishTask
 import io.papermc.hangarpublishplugin.internal.util.capitalized
 
 plugins {
@@ -129,6 +130,10 @@ val supported = paperVersions
     .split(",")
     .map { it.trim() }
 
+tasks.withType<HangarPublishTask> {
+    notCompatibleWithConfigurationCache("Do not cache artifacts")
+}
+
 hangarPublish {
     publications.register("WaystonesRelease") {
         version = pluginVersion
@@ -159,6 +164,10 @@ hangarPublish {
             }
         }
     }
+}
+
+tasks.modrinth {
+    notCompatibleWithConfigurationCache("Do not cache artifacts")
 }
 
 modrinth {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
The publishing plugins are not compatible with Gradle 9.0 at this time. This commit reverts the buildscripts back to 8.14 for the moment to ensure we don't experience further interruptions in plugin deployments. This keeps the build cache configurations however, and disables them in publish tasks to avoid annoying errors.