### PR TITLE
chore: Update Waystones to MC 26.1.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,11 +5,11 @@ import io.papermc.hangarpublishplugin.internal.util.capitalized
 plugins {
     id("java")
     id("idea")
-    id("org.jetbrains.kotlin.jvm") version "2.2.0"
-    id("com.gradleup.shadow") version "8.3.6"
-    id("dev.s7a.gradle.minecraft.server") version "3.2.1"
-    id("com.google.devtools.ksp") version "2.2.0-2.0.2"
-    id("io.gitlab.arturbosch.detekt") version "1.23.8"
+    id("org.jetbrains.kotlin.jvm") version "2.3.0"
+    id("com.gradleup.shadow") version "9.4.1"
+    id("dev.s7a.gradle.minecraft.server") version "4.0.2"
+    id("io.insert-koin.compiler.plugin") version "1.0.0-RC1"
+    id("dev.detekt") version "2.0.0-alpha.2"
     id("io.papermc.hangar-publish-plugin") version "0.1.3"
     id("com.modrinth.minotaur") version "2.8.7"
     id("org.flywaydb.flyway") version "11.10.5"
@@ -27,7 +27,11 @@ repositories {
 }
 
 java {
-    toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+    toolchain.languageVersion.set(JavaLanguageVersion.of(25))
+}
+
+kotlin {
+    jvmToolchain(25)
 }
 
 val kotlinVersion: String by project
@@ -45,9 +49,11 @@ buildscript {
 }
 
 dependencies {
-    compileOnly("io.papermc.paper:paper-api:$buildPaperVersion-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:$buildPaperVersion.build.+")
     implementation("org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion")
     implementation("io.insert-koin:koin-core:$koinVersion")
+    implementation("io.insert-koin:koin-annotations:$koinVersion")
+
     implementation("org.bstats:bstats-bukkit:$bstatsVersion")
     shadow("io.arrow-kt:arrow-core:$arrowVersion")
     // Database dependencies
@@ -55,10 +61,8 @@ dependencies {
     shadow("org.xerial:sqlite-jdbc:$sqliteVersion")
     shadow("com.mysql:mysql-connector-j:$mysqlVersion")
 
-    api("io.insert-koin:koin-annotations:2.0.1-RC1")
-    ksp("io.insert-koin:koin-ksp-compiler:2.0.1-RC1")
 
-    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.8")
+    detektPlugins("dev.detekt:detekt-rules-ktlint-wrapper:2.0.0-alpha.2")
 
     testImplementation("io.mockk:mockk:1.14.2")
     testImplementation("io.kotest:kotest-runner-junit5:5.9.1")
@@ -148,6 +152,7 @@ tasks.build {
 }
 
 tasks.register("buildPlugin") {
+    notCompatibleWithConfigurationCache("Do not cache artifacts")
     dependsOn("shadowJar")
 
     doFirst {
@@ -166,6 +171,7 @@ detekt {
 }
 
 tasks.register<LaunchMinecraftServerTask>("testPlugin") {
+    notCompatibleWithConfigurationCache("Do not cache artifacts")
     dependsOn("buildPlugin")
     jarUrl.set(LaunchMinecraftServerTask.JarUrl.Paper(buildPaperVersion))
     agreeEula.set(true)

--- a/config/detekt.yml
+++ b/config/detekt.yml
@@ -1,7 +1,7 @@
 complexity:
   LongParameterList:
-    constructorThreshold: 25
-    functionThreshold: 10
+    allowedConstructorParameters: 25
+    allowedFunctionParameters: 10
   TooManyFunctions:
     ignorePrivate: true
   CognitiveComplexMethod:
@@ -23,28 +23,31 @@ potential-bugs:
     active: true
 empty-blocks:
   active: true
-formatting:
-  FinalNewline:
-    autoCorrect: true
-  SpacingAroundColon:
-    autoCorrect: true
-  NoConsecutiveBlankLines:
-    autoCorrect: true
-  NoMultipleSpaces:
-    autoCorrect: true
-  NoUnusedImports:
-    active: true
-    autoCorrect: true
+ktlint:
+  active: false
+#  Wrapping:
+#    active: false
+#  FinalNewline:
+#    autoCorrect: true
+#  SpacingAroundColon:
+#    autoCorrect: true
+#  NoConsecutiveBlankLines:
+#    autoCorrect: true
+#  NoMultipleSpaces:
+#    autoCorrect: true
+#  NoUnusedImports:
+#    active: true
+#    autoCorrect: true
 style:
   MagicNumber:
     active: false
   ReturnCount:
     active: false
-  UnusedImports:
+  UnusedImport:
     active: true
   UnusedPrivateClass:
     active: true
-  UnusedPrivateMember:
+  UnusedPrivateProperty:
     active: true
   OptionalUnit:
     active: true

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,12 +5,12 @@ version=2.1.4
 # x-release-please-end
 
 bstatsVersion=3.1.0
-buildPaperVersion=1.21.11
-pluginApiVersion=1.21
-paperVersions=1.21.11
+buildPaperVersion=26.1.2
+pluginApiVersion=26.1
+paperVersions=26.1
 pluginWebsite=https://github.com/AtriusX/Waystones
-kotlinVersion=2.2.0
-koinVersion=4.1.0-RC1
+kotlinVersion=2.3.0
+koinVersion=4.2.1
 arrowVersion=2.1.2
 flywayVersion=11.10.5
 sqliteVersion=3.50.3.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,6 +4,7 @@
 
 pluginManagement {
     repositories {
+        mavenCentral()
         gradlePluginPortal()
     }
 }

--- a/src/main/kotlin/xyz/atrius/waystones/Waystones.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/Waystones.kt
@@ -1,21 +1,39 @@
 package xyz.atrius.waystones
 
-import org.koin.core.Koin
-import org.koin.ksp.generated.module
+import org.koin.core.annotation.KoinApplication
+import org.koin.dsl.module
+import org.koin.plugin.module.dsl.startKoin
 import xyz.atrius.waystones.config.DatabaseModule
 import xyz.atrius.waystones.config.WaystonesModule
 import xyz.atrius.waystones.internal.KotlinPlugin
 import xyz.atrius.waystones.internal.PluginEntrypoint
 
+@KoinApplication(modules = [WaystonesModule::class, DatabaseModule::class])
+class WaystonesKoinApp
+
+typealias KoinApp =
+    org.koin.core.KoinApplication
+
 @PluginEntrypoint
-class Waystones : KotlinPlugin(
-    WaystonesModule.module,
-    DatabaseModule.module,
-) {
+class Waystones : KotlinPlugin() {
 
-    override fun enable(koin: Koin) =
-        enablePlugin<WaystonesInitializer>(koin)
+    private lateinit var koin: KoinApp
 
-    override fun disable(koin: Koin) =
-        disablePlugin<WaystonesInitializer>(koin)
+    private fun defaultModule() = module {
+        single<KotlinPlugin> { this@Waystones }
+    }
+
+    override fun onEnable() {
+        config.options().copyDefaults(true)
+        saveConfig()
+
+        koin = startKoin<WaystonesKoinApp> {
+            modules(defaultModule())
+        }
+        koin.koin.get<WaystonesInitializer>().enable(this)
+    }
+
+    override fun onDisable() {
+        koin.koin.get<WaystonesInitializer>().disable(this)
+    }
 }

--- a/src/main/kotlin/xyz/atrius/waystones/advancement/BlockedAdvancement.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/advancement/BlockedAdvancement.kt
@@ -5,7 +5,7 @@ import org.koin.core.annotation.Single
 import xyz.atrius.waystones.manager.LocalizationManager
 import xyz.atrius.waystones.provider.AdvancementProvider
 
-@Single
+@Single(binds = [AdvancementProvider::class])
 class BlockedAdvancement(
     localization: LocalizationManager,
     secretTunnelAdvancement: SecretTunnelAdvancement,

--- a/src/main/kotlin/xyz/atrius/waystones/advancement/CleanEnergyAdvancement.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/advancement/CleanEnergyAdvancement.kt
@@ -6,7 +6,7 @@ import xyz.atrius.waystones.data.json.advancement.AdvancementType
 import xyz.atrius.waystones.manager.LocalizationManager
 import xyz.atrius.waystones.provider.AdvancementProvider
 
-@Single
+@Single(binds = [AdvancementProvider::class])
 class CleanEnergyAdvancement(
     localization: LocalizationManager,
     heavyArtilleryAdvancement: HeavyArtilleryAdvancement,

--- a/src/main/kotlin/xyz/atrius/waystones/advancement/GigawarpsAdvancement.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/advancement/GigawarpsAdvancement.kt
@@ -6,7 +6,7 @@ import xyz.atrius.waystones.data.json.advancement.AdvancementType
 import xyz.atrius.waystones.manager.LocalizationManager
 import xyz.atrius.waystones.provider.AdvancementProvider
 
-@Single
+@Single(binds = [AdvancementProvider::class])
 class GigawarpsAdvancement(
     localization: LocalizationManager,
     cleanEnergyAdvancement: CleanEnergyAdvancement,

--- a/src/main/kotlin/xyz/atrius/waystones/advancement/HeavyArtilleryAdvancement.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/advancement/HeavyArtilleryAdvancement.kt
@@ -6,7 +6,7 @@ import xyz.atrius.waystones.data.json.advancement.AdvancementType
 import xyz.atrius.waystones.manager.LocalizationManager
 import xyz.atrius.waystones.provider.AdvancementProvider
 
-@Single
+@Single(binds = [AdvancementProvider::class])
 class HeavyArtilleryAdvancement(
     localization: LocalizationManager,
     secretTunnelAdvancement: SecretTunnelAdvancement,

--- a/src/main/kotlin/xyz/atrius/waystones/advancement/HowLowCanYouGoAdvancement.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/advancement/HowLowCanYouGoAdvancement.kt
@@ -4,7 +4,7 @@ import org.bukkit.Material
 import xyz.atrius.waystones.manager.LocalizationManager
 import xyz.atrius.waystones.provider.AdvancementProvider
 
-// @Single Disabled until the advancement is useful
+// @Single(binds = [AdvancementProvider::class]) Disabled until the advancement is useful
 class HowLowCanYouGoAdvancement(
     localization: LocalizationManager,
     secretTunnelAdvancement: SecretTunnelAdvancement,

--- a/src/main/kotlin/xyz/atrius/waystones/advancement/IDontFeelSoGoodAdvancement.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/advancement/IDontFeelSoGoodAdvancement.kt
@@ -5,7 +5,7 @@ import org.koin.core.annotation.Single
 import xyz.atrius.waystones.manager.LocalizationManager
 import xyz.atrius.waystones.provider.AdvancementProvider
 
-@Single
+@Single(binds = [AdvancementProvider::class])
 class IDontFeelSoGoodAdvancement(
     localization: LocalizationManager,
     secretTunnelAdvancement: SecretTunnelAdvancement,

--- a/src/main/kotlin/xyz/atrius/waystones/advancement/QuantumDomesticationAdvancement.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/advancement/QuantumDomesticationAdvancement.kt
@@ -5,7 +5,7 @@ import org.koin.core.annotation.Single
 import xyz.atrius.waystones.manager.LocalizationManager
 import xyz.atrius.waystones.provider.AdvancementProvider
 
-@Single
+@Single(binds = [AdvancementProvider::class])
 class QuantumDomesticationAdvancement(
     localization: LocalizationManager,
     secretTunnelAdvancement: SecretTunnelAdvancement,

--- a/src/main/kotlin/xyz/atrius/waystones/advancement/SecretTunnelAdvancement.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/advancement/SecretTunnelAdvancement.kt
@@ -5,7 +5,7 @@ import org.koin.core.annotation.Single
 import xyz.atrius.waystones.manager.LocalizationManager
 import xyz.atrius.waystones.provider.AdvancementProvider
 
-@Single
+@Single(binds = [AdvancementProvider::class])
 class SecretTunnelAdvancement(
     localization: LocalizationManager,
     waystonesAdvancement: WaystonesAdvancement,

--- a/src/main/kotlin/xyz/atrius/waystones/advancement/ShootTheMessengerAdvancement.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/advancement/ShootTheMessengerAdvancement.kt
@@ -6,7 +6,7 @@ import xyz.atrius.waystones.data.json.advancement.AdvancementType
 import xyz.atrius.waystones.manager.LocalizationManager
 import xyz.atrius.waystones.provider.AdvancementProvider
 
-@Single
+@Single(binds = [AdvancementProvider::class])
 class ShootTheMessengerAdvancement(
     localization: LocalizationManager,
     unlimitedPowerAdvancement: UnlimitedPowerAdvancement,

--- a/src/main/kotlin/xyz/atrius/waystones/advancement/UnlimitedPowerAdvancement.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/advancement/UnlimitedPowerAdvancement.kt
@@ -6,7 +6,7 @@ import xyz.atrius.waystones.data.json.advancement.AdvancementType
 import xyz.atrius.waystones.manager.LocalizationManager
 import xyz.atrius.waystones.provider.AdvancementProvider
 
-@Single
+@Single(binds = [AdvancementProvider::class])
 class UnlimitedPowerAdvancement(
     localization: LocalizationManager,
     heavyArtilleryAdvancement: HeavyArtilleryAdvancement,

--- a/src/main/kotlin/xyz/atrius/waystones/advancement/WaystonesAdvancement.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/advancement/WaystonesAdvancement.kt
@@ -5,7 +5,7 @@ import org.koin.core.annotation.Single
 import xyz.atrius.waystones.manager.LocalizationManager
 import xyz.atrius.waystones.provider.AdvancementProvider
 
-@Single
+@Single(binds = [AdvancementProvider::class])
 class WaystonesAdvancement(
     localization: LocalizationManager,
 ) : AdvancementProvider(

--- a/src/main/kotlin/xyz/atrius/waystones/animation/AnimationManager.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/animation/AnimationManager.kt
@@ -3,6 +3,7 @@ package xyz.atrius.waystones.animation
 import org.bukkit.Bukkit
 import org.bukkit.Location
 import org.bukkit.entity.Player
+import org.koin.core.annotation.Provided
 import org.koin.core.annotation.Single
 import xyz.atrius.waystones.animation.effect.TeleportEffect
 import xyz.atrius.waystones.data.config.property.WaitTimeProperty
@@ -12,7 +13,7 @@ import xyz.atrius.waystones.utility.scheduleRepeatingAutoCancelTask
 @Single
 class AnimationManager(
     private val waitTime: WaitTimeProperty,
-    private val plugin: KotlinPlugin,
+    @Provided private val plugin: KotlinPlugin,
 ) {
 
     private val scheduler = Bukkit.getScheduler()

--- a/src/main/kotlin/xyz/atrius/waystones/command/waystones/InfoCommand.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/command/waystones/InfoCommand.kt
@@ -4,6 +4,7 @@ import com.mojang.brigadier.Command
 import com.mojang.brigadier.builder.ArgumentBuilder
 import io.papermc.paper.command.brigadier.CommandSourceStack
 import org.bukkit.entity.Player
+import org.koin.core.annotation.Provided
 import org.koin.core.annotation.Single
 import xyz.atrius.waystones.internal.KotlinPlugin
 import xyz.atrius.waystones.manager.LocalizationManager
@@ -11,7 +12,7 @@ import xyz.atrius.waystones.utility.translateColors
 
 @Single
 class InfoCommand(
-    plugin: KotlinPlugin,
+    @Provided plugin: KotlinPlugin,
     private val localization: LocalizationManager,
 ) : WaystoneSubcommand {
 

--- a/src/main/kotlin/xyz/atrius/waystones/config/DatabaseModule.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/config/DatabaseModule.kt
@@ -4,6 +4,7 @@ import org.bstats.bukkit.Metrics
 import org.bstats.charts.SimplePie
 import org.flywaydb.core.Flyway
 import org.koin.core.annotation.Module
+import org.koin.core.annotation.Provided
 import org.koin.core.annotation.Single
 import org.slf4j.LoggerFactory
 import xyz.atrius.waystones.internal.KotlinPlugin
@@ -14,8 +15,8 @@ object DatabaseModule {
 
     @Single
     fun getDatabaseConfiguration(
-        plugin: KotlinPlugin,
-        metrics: Metrics,
+        @Provided plugin: KotlinPlugin,
+        @Provided metrics: Metrics,
     ): DatabaseProperties {
         logger.info("Attempting to load database configuration...")
 
@@ -47,7 +48,7 @@ object DatabaseModule {
 
     @Single
     fun configureFlyway(
-        plugin: KotlinPlugin,
+        @Provided plugin: KotlinPlugin,
         props: DatabaseProperties,
     ): Flyway = Flyway
         .configure(this::class.java.classLoader)

--- a/src/main/kotlin/xyz/atrius/waystones/config/DatabaseProperties.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/config/DatabaseProperties.kt
@@ -1,5 +1,6 @@
 package xyz.atrius.waystones.config
 
+import org.koin.core.annotation.Provided
 import xyz.atrius.waystones.internal.KotlinPlugin
 
 enum class SupportedDatabase(
@@ -21,7 +22,7 @@ data class DatabaseProperties(
     val databaseName: String? = null,
 ) {
 
-    fun getHostUrl(plugin: KotlinPlugin): String {
+    fun getHostUrl(@Provided plugin: KotlinPlugin): String {
         // We should configure flyway to pull migrations from the correct database directory
         val url = when (type) {
             SupportedDatabase.SQLITE -> plugin.dataFolder.resolve("waystones.db")

--- a/src/main/kotlin/xyz/atrius/waystones/config/WaystonesModule.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/config/WaystonesModule.kt
@@ -8,6 +8,7 @@ import org.bukkit.Material
 import org.koin.core.annotation.ComponentScan
 import org.koin.core.annotation.Module
 import org.koin.core.annotation.Named
+import org.koin.core.annotation.Provided
 import org.koin.core.annotation.Single
 import xyz.atrius.waystones.data.json.serializer.MaterialTypeAdapter
 import xyz.atrius.waystones.internal.KotlinPlugin
@@ -38,6 +39,6 @@ object WaystonesModule {
     fun defaultPluginLocale(): Locale = Locale.ENGLISH
 
     @Single(createdAtStart = true)
-    fun metrics(plugin: KotlinPlugin): Metrics =
+    fun metrics(@Provided plugin: KotlinPlugin): Metrics =
         Metrics(plugin, BSTATS_PLUGIN_ID)
 }

--- a/src/main/kotlin/xyz/atrius/waystones/crafting/CompassRecipe.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/crafting/CompassRecipe.kt
@@ -1,6 +1,7 @@
 package xyz.atrius.waystones.crafting
 
 import org.bukkit.Material
+import org.koin.core.annotation.Provided
 import org.koin.core.annotation.Single
 import xyz.atrius.waystones.data.config.property.KeyRecipeProperty
 import xyz.atrius.waystones.internal.KotlinPlugin
@@ -12,7 +13,7 @@ import xyz.atrius.waystones.utility.toKey
 
 @Single
 class CompassRecipe(
-    plugin: KotlinPlugin,
+    @Provided plugin: KotlinPlugin,
     defaultKeyProvider: DefaultKeyProvider,
     private val keyRecipe: KeyRecipeProperty,
 ) : CraftingRecipe("is_warp_key".toKey(plugin), defaultKeyProvider.getKey()) {

--- a/src/main/kotlin/xyz/atrius/waystones/data/JsonFile.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/data/JsonFile.kt
@@ -1,6 +1,7 @@
 package xyz.atrius.waystones.data
 
 import com.google.gson.Gson
+import org.koin.core.annotation.Provided
 import org.slf4j.LoggerFactory
 import xyz.atrius.waystones.internal.KotlinPlugin
 import java.io.File
@@ -11,7 +12,7 @@ import kotlin.reflect.KClass
 open class JsonFile<T : Any>(
     name: String,
     private val gson: Gson,
-    private val plugin: KotlinPlugin,
+    @Provided private val plugin: KotlinPlugin,
     private val type: KClass<out T>,
 ) {
 

--- a/src/main/kotlin/xyz/atrius/waystones/data/config/property/BaseDistanceProperty.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/data/config/property/BaseDistanceProperty.kt
@@ -4,7 +4,7 @@ import com.mojang.brigadier.arguments.IntegerArgumentType
 import org.koin.core.annotation.Single
 import xyz.atrius.waystones.data.config.ConfigProperty
 
-@Single
+@Single(binds = [ConfigProperty::class])
 class BaseDistanceProperty : ConfigProperty<Int>(
     property = "base-distance",
     default = 100,

--- a/src/main/kotlin/xyz/atrius/waystones/data/config/property/DamageStopsWarpingProperty.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/data/config/property/DamageStopsWarpingProperty.kt
@@ -4,7 +4,7 @@ import com.mojang.brigadier.arguments.BoolArgumentType
 import org.koin.core.annotation.Single
 import xyz.atrius.waystones.data.config.ConfigProperty
 
-@Single
+@Single(binds = [ConfigProperty::class])
 class DamageStopsWarpingProperty : ConfigProperty<Boolean>(
     property = "damage-stops-warping",
     default = true,

--- a/src/main/kotlin/xyz/atrius/waystones/data/config/property/EnableAdvancementsProperty.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/data/config/property/EnableAdvancementsProperty.kt
@@ -4,7 +4,7 @@ import com.mojang.brigadier.arguments.BoolArgumentType
 import org.koin.core.annotation.Single
 import xyz.atrius.waystones.data.config.ConfigProperty
 
-@Single
+@Single(binds = [ConfigProperty::class])
 class EnableAdvancementsProperty : ConfigProperty<Boolean>(
     property = "enable-advancements",
     default = true,

--- a/src/main/kotlin/xyz/atrius/waystones/data/config/property/EnableKeyItemsProperty.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/data/config/property/EnableKeyItemsProperty.kt
@@ -4,7 +4,7 @@ import com.mojang.brigadier.arguments.BoolArgumentType
 import org.koin.core.annotation.Single
 import xyz.atrius.waystones.data.config.ConfigProperty
 
-@Single
+@Single(binds = [ConfigProperty::class])
 class EnableKeyItemsProperty : ConfigProperty<Boolean>(
     property = "enable-key-items",
     default = true,

--- a/src/main/kotlin/xyz/atrius/waystones/data/config/property/EnablePortalSicknessProperty.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/data/config/property/EnablePortalSicknessProperty.kt
@@ -4,7 +4,7 @@ import com.mojang.brigadier.arguments.BoolArgumentType
 import org.koin.core.annotation.Single
 import xyz.atrius.waystones.data.config.ConfigProperty
 
-@Single
+@Single(binds = [ConfigProperty::class])
 class EnablePortalSicknessProperty : ConfigProperty<Boolean>(
     property = "enable-portal-sickness",
     default = true,

--- a/src/main/kotlin/xyz/atrius/waystones/data/config/property/FallbackLocaleProperty.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/data/config/property/FallbackLocaleProperty.kt
@@ -7,7 +7,7 @@ import xyz.atrius.waystones.data.config.ConfigProperty
 import xyz.atrius.waystones.utility.sanitizedStringFormat
 import java.util.Locale
 
-@Single
+@Single(binds = [ConfigProperty::class])
 class FallbackLocaleProperty(
     @Named("supportedLocales")
     private val supportedLocales: Set<Locale>,

--- a/src/main/kotlin/xyz/atrius/waystones/data/config/property/JumpWorldsProperty.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/data/config/property/JumpWorldsProperty.kt
@@ -4,7 +4,7 @@ import com.mojang.brigadier.arguments.BoolArgumentType
 import org.koin.core.annotation.Single
 import xyz.atrius.waystones.data.config.ConfigProperty
 
-@Single
+@Single(binds = [ConfigProperty::class])
 class JumpWorldsProperty : ConfigProperty<Boolean>(
     property = "jump-worlds",
     default = true,

--- a/src/main/kotlin/xyz/atrius/waystones/data/config/property/KeyRecipeProperty.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/data/config/property/KeyRecipeProperty.kt
@@ -6,7 +6,7 @@ import xyz.atrius.waystones.command.resolver.EnumArgumentType
 import xyz.atrius.waystones.data.config.ListConfigProperty
 import xyz.atrius.waystones.utility.sanitizedStringFormat
 
-@Single
+@Single(binds = [ListConfigProperty::class])
 class KeyRecipeProperty : ListConfigProperty<Material>(
     property = "key-recipe",
     default = listOf(

--- a/src/main/kotlin/xyz/atrius/waystones/data/config/property/LimitDistanceProperty.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/data/config/property/LimitDistanceProperty.kt
@@ -4,7 +4,7 @@ import com.mojang.brigadier.arguments.BoolArgumentType
 import org.koin.core.annotation.Single
 import xyz.atrius.waystones.data.config.ConfigProperty
 
-@Single
+@Single(binds = [ConfigProperty::class])
 class LimitDistanceProperty : ConfigProperty<Boolean>(
     property = "limit-distance",
     default = true,

--- a/src/main/kotlin/xyz/atrius/waystones/data/config/property/MaxBoostProperty.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/data/config/property/MaxBoostProperty.kt
@@ -4,7 +4,7 @@ import com.mojang.brigadier.arguments.IntegerArgumentType
 import org.koin.core.annotation.Single
 import xyz.atrius.waystones.data.config.ConfigProperty
 
-@Single
+@Single(binds = [ConfigProperty::class])
 class MaxBoostProperty : ConfigProperty<Int>(
     property = "max-boost",
     default = 50,

--- a/src/main/kotlin/xyz/atrius/waystones/data/config/property/MaxWarpSizeProperty.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/data/config/property/MaxWarpSizeProperty.kt
@@ -4,7 +4,7 @@ import com.mojang.brigadier.arguments.IntegerArgumentType
 import org.koin.core.annotation.Single
 import xyz.atrius.waystones.data.config.ConfigProperty
 
-@Single
+@Single(binds = [ConfigProperty::class])
 class MaxWarpSizeProperty : ConfigProperty<Int>(
     property = "max-warp-size",
     default = 25,

--- a/src/main/kotlin/xyz/atrius/waystones/data/config/property/PortalSicknessChanceProperty.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/data/config/property/PortalSicknessChanceProperty.kt
@@ -4,7 +4,7 @@ import com.mojang.brigadier.arguments.DoubleArgumentType
 import org.koin.core.annotation.Single
 import xyz.atrius.waystones.data.config.ConfigProperty
 
-@Single
+@Single(binds = [ConfigProperty::class])
 class PortalSicknessChanceProperty : ConfigProperty<Double>(
     property = "portal-sickness-chance",
     default = 5.0,

--- a/src/main/kotlin/xyz/atrius/waystones/data/config/property/PortalSicknessDamageProperty.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/data/config/property/PortalSicknessDamageProperty.kt
@@ -4,7 +4,7 @@ import com.mojang.brigadier.arguments.DoubleArgumentType
 import org.koin.core.annotation.Single
 import xyz.atrius.waystones.data.config.ConfigProperty
 
-@Single
+@Single(binds = [ConfigProperty::class])
 class PortalSicknessDamageProperty : ConfigProperty<Double>(
     property = "portal-sickness-damage",
     default = 5.0,

--- a/src/main/kotlin/xyz/atrius/waystones/data/config/property/PortalSicknessWarpingProperty.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/data/config/property/PortalSicknessWarpingProperty.kt
@@ -6,7 +6,7 @@ import xyz.atrius.waystones.data.config.ConfigProperty
 import xyz.atrius.waystones.data.config.property.type.SicknessOption
 import xyz.atrius.waystones.utility.sanitizedStringFormat
 
-@Single
+@Single(binds = [ConfigProperty::class])
 class PortalSicknessWarpingProperty : ConfigProperty<SicknessOption>(
     property = "portal-sickness-warping",
     default = SicknessOption.DAMAGE_ON_TELEPORT,

--- a/src/main/kotlin/xyz/atrius/waystones/data/config/property/PowerCostProperty.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/data/config/property/PowerCostProperty.kt
@@ -4,7 +4,7 @@ import com.mojang.brigadier.arguments.IntegerArgumentType
 import org.koin.core.annotation.Single
 import xyz.atrius.waystones.data.config.ConfigProperty
 
-@Single
+@Single(binds = [ConfigProperty::class])
 class PowerCostProperty : ConfigProperty<Int>(
     property = "power-cost",
     default = 1,

--- a/src/main/kotlin/xyz/atrius/waystones/data/config/property/RelinkableKeysProperty.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/data/config/property/RelinkableKeysProperty.kt
@@ -4,7 +4,7 @@ import com.mojang.brigadier.arguments.BoolArgumentType
 import org.koin.core.annotation.Single
 import xyz.atrius.waystones.data.config.ConfigProperty
 
-@Single
+@Single(binds = [ConfigProperty::class])
 class RelinkableKeysProperty : ConfigProperty<Boolean>(
     property = "relinkable-keys",
     default = true,

--- a/src/main/kotlin/xyz/atrius/waystones/data/config/property/RequirePowerProperty.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/data/config/property/RequirePowerProperty.kt
@@ -6,7 +6,7 @@ import xyz.atrius.waystones.data.config.ConfigProperty
 import xyz.atrius.waystones.data.config.property.type.Power
 import xyz.atrius.waystones.utility.sanitizedStringFormat
 
-@Single
+@Single(binds = [ConfigProperty::class])
 class RequirePowerProperty : ConfigProperty<Power>(
     property = "require-power",
     default = Power.INTER_DIMENSION,

--- a/src/main/kotlin/xyz/atrius/waystones/data/config/property/SingleUseProperty.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/data/config/property/SingleUseProperty.kt
@@ -4,7 +4,7 @@ import com.mojang.brigadier.arguments.BoolArgumentType
 import org.koin.core.annotation.Single
 import xyz.atrius.waystones.data.config.ConfigProperty
 
-@Single
+@Single(binds = [ConfigProperty::class])
 class SingleUseProperty : ConfigProperty<Boolean>(
     property = "single-use",
     default = false,

--- a/src/main/kotlin/xyz/atrius/waystones/data/config/property/WaitTimeProperty.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/data/config/property/WaitTimeProperty.kt
@@ -4,7 +4,7 @@ import com.mojang.brigadier.arguments.DoubleArgumentType
 import org.koin.core.annotation.Single
 import xyz.atrius.waystones.data.config.ConfigProperty
 
-@Single
+@Single(binds = [ConfigProperty::class])
 class WaitTimeProperty : ConfigProperty<Double>(
     property = "wait-time",
     default = 3.0,

--- a/src/main/kotlin/xyz/atrius/waystones/data/config/property/WarpAnimationsProperty.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/data/config/property/WarpAnimationsProperty.kt
@@ -4,7 +4,7 @@ import com.mojang.brigadier.arguments.BoolArgumentType
 import org.koin.core.annotation.Single
 import xyz.atrius.waystones.data.config.ConfigProperty
 
-@Single
+@Single(binds = [ConfigProperty::class])
 class WarpAnimationsProperty : ConfigProperty<Boolean>(
     property = "warp-animations",
     default = true,

--- a/src/main/kotlin/xyz/atrius/waystones/data/config/property/WorldRatioProperty.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/data/config/property/WorldRatioProperty.kt
@@ -4,7 +4,7 @@ import com.mojang.brigadier.arguments.DoubleArgumentType
 import org.koin.core.annotation.Single
 import xyz.atrius.waystones.data.config.ConfigProperty
 
-@Single
+@Single(binds = [ConfigProperty::class])
 class WorldRatioProperty : ConfigProperty<Double>(
     property = "default-world-ratio",
     default = 1.0,

--- a/src/main/kotlin/xyz/atrius/waystones/internal/KotlinPlugin.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/internal/KotlinPlugin.kt
@@ -1,38 +1,5 @@
 package xyz.atrius.waystones.internal
 
 import org.bukkit.plugin.java.JavaPlugin
-import org.koin.core.Koin
-import org.koin.core.context.startKoin
-import org.koin.core.module.Module
-import org.koin.dsl.module
 
-open class KotlinPlugin(private vararg val modules: Module) : JavaPlugin() {
-    private val koin: Koin = startKoin {
-        // Load modules into scope
-        modules(defaultModule(), *modules)
-    }.koin
-
-    open fun enable(koin: Koin) {}
-
-    open fun disable(koin: Koin) {}
-
-    open fun defaultModule(): Module = module {
-        single { this@KotlinPlugin }
-    }
-
-    final override fun onEnable() {
-        config.options().copyDefaults(true)
-        saveConfig()
-        enable(koin)
-    }
-
-    final override fun onDisable() = disable(koin)
-
-    inline fun <reified T : PluginInitializer> enablePlugin(koin: Koin) {
-        koin.get<T>().enable(this)
-    }
-
-    inline fun <reified T : PluginInitializer> disablePlugin(koin: Koin) {
-        koin.get<T>().disable(this)
-    }
-}
+open class KotlinPlugin : JavaPlugin()

--- a/src/main/kotlin/xyz/atrius/waystones/manager/AdvancementManager.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/manager/AdvancementManager.kt
@@ -2,6 +2,7 @@ package xyz.atrius.waystones.manager
 
 import com.google.gson.Gson
 import org.bukkit.entity.Player
+import org.koin.core.annotation.Provided
 import org.koin.core.annotation.Single
 import org.slf4j.LoggerFactory
 import xyz.atrius.waystones.data.config.property.EnableAdvancementsProperty
@@ -11,7 +12,7 @@ import org.bukkit.advancement.Advancement as SpigotAdvancement
 
 @Single
 class AdvancementManager(
-    private val plugin: KotlinPlugin,
+    @Provided private val plugin: KotlinPlugin,
     private val enableAdvancements: EnableAdvancementsProperty,
     private val gson: Gson,
     private val advancementContainers: List<AdvancementProvider>,

--- a/src/main/kotlin/xyz/atrius/waystones/manager/CommandManager.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/manager/CommandManager.kt
@@ -1,6 +1,7 @@
 package xyz.atrius.waystones.manager
 
 import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents
+import org.koin.core.annotation.Provided
 import org.koin.core.annotation.Single
 import org.slf4j.LoggerFactory
 import xyz.atrius.waystones.command.BaseCommand
@@ -8,7 +9,7 @@ import xyz.atrius.waystones.internal.KotlinPlugin
 
 @Single
 class CommandManager(
-    private val plugin: KotlinPlugin,
+    @Provided private val plugin: KotlinPlugin,
     private val commands: List<BaseCommand<*>>,
 ) {
 

--- a/src/main/kotlin/xyz/atrius/waystones/manager/ConfigManager.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/manager/ConfigManager.kt
@@ -1,5 +1,6 @@
 package xyz.atrius.waystones.manager
 
+import org.koin.core.annotation.Provided
 import org.koin.core.annotation.Single
 import xyz.atrius.waystones.data.config.ConfigProperty
 import xyz.atrius.waystones.data.config.ConfigPropertyBase
@@ -8,7 +9,7 @@ import xyz.atrius.waystones.internal.KotlinPlugin
 
 @Single
 class ConfigManager(
-    val plugin: KotlinPlugin,
+    @Provided val plugin: KotlinPlugin,
     properties: List<ConfigProperty<*>>,
     listProperties: List<ListConfigProperty<*>>,
 ) {

--- a/src/main/kotlin/xyz/atrius/waystones/manager/CraftingRecipeManager.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/manager/CraftingRecipeManager.kt
@@ -1,5 +1,6 @@
 package xyz.atrius.waystones.manager
 
+import org.koin.core.annotation.Provided
 import org.koin.core.annotation.Single
 import org.slf4j.LoggerFactory
 import xyz.atrius.waystones.crafting.CraftingRecipe
@@ -7,7 +8,7 @@ import xyz.atrius.waystones.internal.KotlinPlugin
 
 @Single
 class CraftingRecipeManager(
-    private val plugin: KotlinPlugin,
+    @Provided private val plugin: KotlinPlugin,
     private val recipes: List<CraftingRecipe>,
 ) {
 

--- a/src/main/kotlin/xyz/atrius/waystones/manager/DatabaseManager.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/manager/DatabaseManager.kt
@@ -3,6 +3,7 @@ package xyz.atrius.waystones.manager
 import org.flywaydb.core.Flyway
 import org.flywaydb.core.api.output.MigrateResult
 import org.flywaydb.core.internal.jdbc.RowMapper
+import org.koin.core.annotation.Provided
 import org.koin.core.annotation.Single
 import org.slf4j.LoggerFactory
 import xyz.atrius.waystones.config.DatabaseProperties
@@ -15,9 +16,9 @@ import java.util.concurrent.CompletableFuture
 
 @Single
 class DatabaseManager(
-    private val flyway: Flyway,
-    private val properties: DatabaseProperties,
-    private val plugin: KotlinPlugin,
+    @Provided private val flyway: Flyway,
+    @Provided private val properties: DatabaseProperties,
+    @Provided private val plugin: KotlinPlugin,
 ) : AutoCloseable {
     private var connection: Connection? = null
 

--- a/src/main/kotlin/xyz/atrius/waystones/manager/EventManager.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/manager/EventManager.kt
@@ -1,13 +1,14 @@
 package xyz.atrius.waystones.manager
 
 import org.bukkit.event.Listener
+import org.koin.core.annotation.Provided
 import org.koin.core.annotation.Single
 import org.slf4j.LoggerFactory
 import xyz.atrius.waystones.internal.KotlinPlugin
 
 @Single
 class EventManager(
-    private val plugin: KotlinPlugin,
+    @Provided private val plugin: KotlinPlugin,
     private val listeners: List<Listener>,
 ) {
 

--- a/src/main/kotlin/xyz/atrius/waystones/manager/LocalizationManager.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/manager/LocalizationManager.kt
@@ -3,6 +3,7 @@ package xyz.atrius.waystones.manager
 import arrow.core.mapValuesNotNull
 import org.bukkit.configuration.file.YamlConfiguration
 import org.koin.core.annotation.Named
+import org.koin.core.annotation.Provided
 import org.koin.core.annotation.Single
 import org.slf4j.LoggerFactory
 import xyz.atrius.waystones.data.config.property.FallbackLocaleProperty
@@ -13,7 +14,7 @@ import java.util.Locale
 
 @Single
 class LocalizationManager(
-    private val plugin: KotlinPlugin,
+    @Provided private val plugin: KotlinPlugin,
     @Named("supportedLocales")
     private val supportedLocales: Set<Locale>,
     @Named("defaultPluginLocale")
@@ -40,7 +41,7 @@ class LocalizationManager(
         .any { (_, v) -> v.getTemplate(key) != null }
 
     private data class LocaleConfig(
-        private val plugin: KotlinPlugin,
+        @Provided private val plugin: KotlinPlugin,
         private val locale: Locale,
     ) {
         private val file: File = File(

--- a/src/main/kotlin/xyz/atrius/waystones/repository/WaystoneInfoRepository.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/repository/WaystoneInfoRepository.kt
@@ -3,6 +3,7 @@ package xyz.atrius.waystones.repository
 import org.bukkit.Location
 import org.bukkit.World
 import org.flywaydb.core.internal.jdbc.RowMapper
+import org.koin.core.annotation.Provided
 import org.koin.core.annotation.Single
 import xyz.atrius.waystones.config.DatabaseProperties
 import xyz.atrius.waystones.config.SupportedDatabase
@@ -15,7 +16,7 @@ import java.util.concurrent.CompletableFuture
 @Single
 class WaystoneInfoRepository(
     private val databaseManager: DatabaseManager,
-    private val databaseProperties: DatabaseProperties,
+    @Provided private val databaseProperties: DatabaseProperties,
 ) : RowMapper<WaystoneInfo> {
 
     fun getWaystone(location: Location): CompletableFuture<WaystoneInfo?> {

--- a/src/main/kotlin/xyz/atrius/waystones/service/WarpNameService.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/service/WarpNameService.kt
@@ -2,6 +2,7 @@ package xyz.atrius.waystones.service
 
 import com.google.gson.Gson
 import org.bukkit.Bukkit
+import org.koin.core.annotation.Provided
 import org.koin.core.annotation.Single
 import org.slf4j.LoggerFactory
 import xyz.atrius.waystones.dao.WaystoneInfo
@@ -14,7 +15,7 @@ import xyz.atrius.waystones.utility.expectSizeOrDefault
 @Deprecated("Database support is included now, so this will be phased out in the future")
 class WarpNameService(
     gson: Gson,
-    plugin: KotlinPlugin,
+    @Provided plugin: KotlinPlugin,
     private val waystoneInfoRepository: WaystoneInfoRepository,
     private val waystoneService: WaystoneService,
 ) : JsonFile<HashMap<String, String>>("warpnames", gson, plugin, HashMap<String, String>()::class) {

--- a/src/main/kotlin/xyz/atrius/waystones/service/WorldRatioService.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/service/WorldRatioService.kt
@@ -3,6 +3,7 @@ package xyz.atrius.waystones.service
 import com.google.gson.Gson
 import org.bukkit.Bukkit
 import org.bukkit.World
+import org.koin.core.annotation.Provided
 import org.koin.core.annotation.Single
 import xyz.atrius.waystones.data.JsonFile
 import xyz.atrius.waystones.data.config.property.WorldRatioProperty
@@ -13,7 +14,7 @@ import java.util.UUID
 @Single
 class WorldRatioService(
     gson: Gson,
-    plugin: KotlinPlugin,
+    @Provided plugin: KotlinPlugin,
     private val defaultRatioProperty: WorldRatioProperty,
 ) : JsonFile<RatioConfig>("ratios", gson, plugin, RatioConfig::class), Iterable<Map.Entry<World, Double>> {
 


### PR DESCRIPTION
This is a routine upgrade to make the plugin compatible with the latest version of Minecraft. Unfortunately, as this required an update to JDK 25, this required a bit of refactoring and updating of all dependencies for the sake of compatability.

Later on a bit of cleanup should be done to ensure that this is operating as cleanly as possible.