### PR TITLE
feat: #125 Conditionally show compass coordinates in lore

### DIFF
--- a/src/main/kotlin/xyz/atrius/waystones/data/config/property/ShowCompassCoordinatesProperty.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/data/config/property/ShowCompassCoordinatesProperty.kt
@@ -1,0 +1,13 @@
+package xyz.atrius.waystones.data.config.property
+
+import com.mojang.brigadier.arguments.BoolArgumentType
+import org.koin.core.annotation.Single
+import xyz.atrius.waystones.data.config.ConfigProperty
+
+@Single(binds = [ConfigProperty::class])
+class ShowCompassCoordinatesProperty : ConfigProperty<Boolean>(
+    property = "show-compass-coordinates",
+    default = true,
+    parser = BoolArgumentType.bool(),
+    propertyType = Boolean::class,
+)

--- a/src/main/kotlin/xyz/atrius/waystones/service/LinkService.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/service/LinkService.kt
@@ -14,6 +14,7 @@ import org.bukkit.inventory.meta.CompassMeta
 import org.bukkit.persistence.PersistentDataType
 import org.koin.core.annotation.Single
 import xyz.atrius.waystones.data.config.property.RelinkableKeysProperty
+import xyz.atrius.waystones.data.config.property.ShowCompassCoordinatesProperty
 import xyz.atrius.waystones.manager.LocalizationManager
 import xyz.atrius.waystones.manager.LocalizedString
 import xyz.atrius.waystones.provider.DefaultKeyProvider
@@ -32,6 +33,7 @@ class LinkService(
     private val keyService: KeyService,
     private val defaultKeyProvider: DefaultKeyProvider,
     private val waystoneInfoRepository: WaystoneInfoRepository,
+    private val showCompassCoordinates: ShowCompassCoordinatesProperty,
 ) {
 
     fun process(player: Player, item: ItemStack, block: Block): Either<LinkServiceError, Unit> = either {
@@ -116,11 +118,15 @@ class LinkService(
         }
 
         val name = name ?: localization["unnamed-waystone"].format(player)
-        val lore = localization["link-key-lore", name, lodestone?.locationCode]
-            .format(player)
-            .let(Component::text)
 
-        lore(listOf(lore))
+        if (showCompassCoordinates.value() || player.hasPermission("waystones.admin")) {
+            val lore = localization["link-key-lore", name, lodestone?.locationCode]
+                .format(player)
+                .let(Component::text)
+            lore(listOf(lore))
+        } else {
+            lore(listOf())
+        }
     }
 
     sealed class LinkServiceError(val message: () -> LocalizedString?) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -18,6 +18,7 @@ portal-sickness-damage: 5.0
 relinkable-keys: true
 enable-key-items: true
 enable-advancements: true
+show-compass-coordinates: true
 key-recipe:
   - AIR
   - IRON_INGOT

--- a/src/main/resources/locale-en.yml
+++ b/src/main/resources/locale-en.yml
@@ -93,6 +93,7 @@ property-wait-time-info: "The amount of time (in ticks) the player must wait for
 property-warp-animations-info: "Whether to use particle animations while warping"
 property-default-world-ratio-info: "The world ratio to use for worlds which have no ratio set"
 property-base-distance-info: "The baseline for which all waystones are given as a minimum teleport distance"
+property-show-compass-coordinates-info: "Whether to show waystone coordinates in the compass lore upon linking"
 default-subcommand-desc: "No description provided"
 ws-ratio-subcommand-desc: "Adjust the warp distance ratios between worlds"
 ws-reload-subcommand-desc: "Reload aspects of the plugin"


### PR DESCRIPTION
This is a QoL update to allow admins to disable the visibility of waystone key coordinates in a waystone key's lore tag.

This was requested to help the plugin blend into vanilla gameplay a bit better.

Fixes #125 