### PR TITLE
feat(ownership): Add database schema and config for waystone ownership

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     implementation(plugin(libs.plugins.modrinth))
     implementation(plugin(libs.plugins.flyway))
     implementation(plugin(libs.plugins.buildconfig))
+    implementation(libs.flyway.mysql)
 
     implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))
 }

--- a/src/main/kotlin/xyz/atrius/waystones/dao/WaystoneAuthorizedUser.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/dao/WaystoneAuthorizedUser.kt
@@ -1,0 +1,14 @@
+package xyz.atrius.waystones.dao
+
+import java.util.UUID
+
+/**
+ * Represents an authorized user entry for a waystone.
+ *
+ * @property waystoneUuid The UUID of the waystone this authorization belongs to
+ * @property ownerUuid The UUID of the authorized player
+ */
+data class WaystoneAuthorizedUser(
+    val waystoneUuid: UUID,
+    val ownerUuid: UUID,
+)

--- a/src/main/kotlin/xyz/atrius/waystones/dao/WaystoneInfo.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/dao/WaystoneInfo.kt
@@ -1,24 +1,57 @@
 package xyz.atrius.waystones.dao
 
 import org.bukkit.Location
+import org.bukkit.entity.Player
 import java.util.UUID
 
+/**
+ * Represents a waystone with its location, name, and ownership information.
+ *
+ * @property worldUid The UUID of the world where the waystone is located
+ * @property x The X coordinate of the waystone
+ * @property y The Y coordinate of the waystone
+ * @property z The Z coordinate of the waystone
+ * @property name The display name of the waystone
+ * @property waystoneUuid The unique identifier for this waystone (UUID)
+ * @property primaryOwnerUuid The UUID of the player who owns this waystone
+ * @property isLocked Whether the waystone is locked (only owner can link keys)
+ */
 data class WaystoneInfo(
     val worldUid: UUID,
     val x: Int,
     val y: Int,
     val z: Int,
     val name: String? = null,
+    val waystoneUuid: UUID? = null,
+    val primaryOwnerUuid: UUID? = null,
+    val isLocked: Boolean = false,
 ) {
 
     companion object {
 
-        fun fromLocation(location: Location, name: String? = null): WaystoneInfo = WaystoneInfo(
+        /**
+         * Creates a WaystoneInfo from a location with optional ownership information.
+         *
+         * @param location The Bukkit location of the waystone
+         * @param name Optional display name for the waystone
+         * @param owner Optional player who will own this waystone
+         * @param isLocked Whether the waystone should be locked by default
+         * @return A new WaystoneInfo instance with a generated waystoneUuid
+         */
+        fun fromLocation(
+            location: Location,
+            name: String? = null,
+            owner: Player? = null,
+            isLocked: Boolean = false,
+        ): WaystoneInfo = WaystoneInfo(
             worldUid = location.world.uid,
             x = location.blockX,
             y = location.blockY,
             z = location.blockZ,
             name = name,
+            waystoneUuid = UUID.randomUUID(),
+            primaryOwnerUuid = owner?.uniqueId,
+            isLocked = isLocked,
         )
     }
 }

--- a/src/main/kotlin/xyz/atrius/waystones/data/config/property/WaystoneLockingProperty.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/data/config/property/WaystoneLockingProperty.kt
@@ -1,0 +1,17 @@
+package xyz.atrius.waystones.data.config.property
+
+import org.koin.core.annotation.Single
+import xyz.atrius.waystones.command.resolver.EnumArgumentType
+import xyz.atrius.waystones.data.config.ConfigProperty
+import xyz.atrius.waystones.data.config.property.type.WaystoneLocking
+import xyz.atrius.waystones.utility.sanitizedStringFormat
+
+@Single(binds = [ConfigProperty::class])
+class WaystoneLockingProperty : ConfigProperty<WaystoneLocking>(
+    property = "waystone-locking",
+    default = WaystoneLocking.NONE,
+    parser = EnumArgumentType(WaystoneLocking::class),
+    propertyType = WaystoneLocking::class,
+    format = { it.sanitizedStringFormat() },
+    serialize = { it.name },
+)

--- a/src/main/kotlin/xyz/atrius/waystones/data/config/property/type/WaystoneLocking.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/data/config/property/type/WaystoneLocking.kt
@@ -1,0 +1,32 @@
+package xyz.atrius.waystones.data.config.property.type
+
+/**
+ * Determines how waystone ownership and locking behaves on the server.
+ *
+ * This enum controls whether waystones can be owned by players and how
+ * that ownership affects key linking permissions.
+ */
+enum class WaystoneLocking {
+    /**
+     * All waystones are automatically locked to the player who first links them.
+     * Only the owner can link keys to the waystone. This provides maximum
+     * protection but removes the ability for players to share waystones.
+     */
+    ALL,
+
+    /**
+     * Waystone owners can individually toggle lock status per waystone.
+     * When a waystone is locked, only the owner can link keys to it.
+     * When unlocked, anyone can link keys. This provides flexible
+     * ownership while allowing sharing when desired.
+     */
+    PER_WAYSTONE,
+
+    /**
+     * No ownership or locking is enforced. Any player can link keys
+     * to any waystone regardless of who placed it. This is the default
+     * behavior and maintains backward compatibility with versions
+     * before ownership was introduced.
+     */
+    NONE
+}

--- a/src/main/kotlin/xyz/atrius/waystones/repository/WaystoneAuthorizedUsersRepository.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/repository/WaystoneAuthorizedUsersRepository.kt
@@ -1,0 +1,76 @@
+package xyz.atrius.waystones.repository
+
+import org.flywaydb.core.internal.jdbc.RowMapper
+import org.koin.core.annotation.Provided
+import org.koin.core.annotation.Single
+import xyz.atrius.waystones.config.DatabaseProperties
+import xyz.atrius.waystones.config.SupportedDatabase
+import xyz.atrius.waystones.dao.WaystoneAuthorizedUser
+import xyz.atrius.waystones.manager.DatabaseManager
+import java.sql.ResultSet
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
+
+@Single
+class WaystoneAuthorizedUsersRepository(
+    private val databaseManager: DatabaseManager,
+    @Provided private val databaseProperties: DatabaseProperties,
+) : RowMapper<WaystoneAuthorizedUser> {
+
+    fun isAuthorized(waystoneUuid: UUID, playerUuid: UUID): CompletableFuture<Boolean> {
+        val query = """
+            |select 1
+            |from waystone_authorized_users
+            |where waystone_uuid = ?
+            |  and owner_uuid = ?
+            |limit 1;
+        """.trimMargin()
+        val params = listOf(waystoneUuid.toString(), playerUuid.toString())
+        return databaseManager.queryExists(query, params)
+    }
+
+    fun addAuthorized(waystoneUuid: UUID, playerUuid: UUID): CompletableFuture<Boolean> {
+        val query = when (databaseProperties.type) {
+            SupportedDatabase.MYSQL -> """
+                |insert ignore into waystone_authorized_users (waystone_uuid, owner_uuid)
+                |values (?, ?);
+            """.trimMargin()
+            SupportedDatabase.SQLITE -> """
+                |insert or ignore into waystone_authorized_users (waystone_uuid, owner_uuid)
+                |values (?, ?);
+            """.trimMargin()
+        }
+        val params = listOf(waystoneUuid.toString(), playerUuid.toString())
+        return databaseManager
+            .queryUpdate(query, params)
+            .thenApplyAsync { it > 0 }
+    }
+
+    fun removeAuthorized(waystoneUuid: UUID, playerUuid: UUID): CompletableFuture<Boolean> {
+        val query = """
+            |delete from waystone_authorized_users
+            |where waystone_uuid = ?
+            |  and owner_uuid = ?;
+        """.trimMargin()
+        val params = listOf(waystoneUuid.toString(), playerUuid.toString())
+        return databaseManager
+            .queryUpdate(query, params)
+            .thenApplyAsync { it > 0 }
+    }
+
+    fun getAuthorized(waystoneUuid: UUID): CompletableFuture<List<WaystoneAuthorizedUser>> {
+        val query = """
+            |select waystone_uuid, owner_uuid
+            |from waystone_authorized_users
+            |where waystone_uuid = ?;
+        """.trimMargin()
+        val params = listOf(waystoneUuid.toString())
+        return databaseManager
+            .queryAll(query, params, this)
+    }
+
+    override fun mapRow(rs: ResultSet): WaystoneAuthorizedUser = WaystoneAuthorizedUser(
+        waystoneUuid = UUID.fromString(rs.getString("waystone_uuid")),
+        ownerUuid = UUID.fromString(rs.getString("owner_uuid")),
+    )
+}

--- a/src/main/kotlin/xyz/atrius/waystones/repository/WaystoneInfoRepository.kt
+++ b/src/main/kotlin/xyz/atrius/waystones/repository/WaystoneInfoRepository.kt
@@ -74,21 +74,29 @@ class WaystoneInfoRepository(
     }
 
     fun save(info: WaystoneInfo): CompletableFuture<Int> {
-        val query = when (databaseProperties.type) {
-            SupportedDatabase.MYSQL -> """
-                |insert into waystone_info (world_uid, x, y, z, name)
-                |values (?, ?, ?, ?, ?)
-                |on duplicate key update
-                |   name = values(name)
-            """.trimMargin()
+        val conflictClause = when (databaseProperties.type) {
             SupportedDatabase.SQLITE -> """
-                |insert into waystone_info (world_uid, x, y, z, name)
-                |values (?, ?, ?, ?, ?)
                 |on conflict (world_uid, x, y, z) do update set
-                |   name = excluded.name
+                |   name = excluded.name,
+                |   primary_owner_uuid = excluded.primary_owner_uuid,
+                |   is_locked = excluded.is_locked
+            """.trimMargin()
+            SupportedDatabase.MYSQL -> """
+                |on duplicate key update
+                |   name = values(name),
+                |   primary_owner_uuid = values(primary_owner_uuid),
+                |   is_locked = values(is_locked)
             """.trimMargin()
         }
-        val params = listOf(info.worldUid, info.x, info.y, info.z, info.name)
+        val query = """
+            |insert into waystone_info (world_uid, x, y, z, name, waystone_uuid, primary_owner_uuid, is_locked)
+            |values (?, ?, ?, ?, ?, ?, ?, ?)
+            |$conflictClause
+        """.trimMargin()
+        val params = listOf(
+            info.worldUid, info.x, info.y, info.z, info.name,
+            info.waystoneUuid?.toString(), info.primaryOwnerUuid?.toString(), info.isLocked,
+        )
 
         return databaseManager
             .queryUpdate(query, params)
@@ -119,11 +127,25 @@ class WaystoneInfoRepository(
             .queryUpdate(query, params)
     }
 
+    fun getLockedCount(): CompletableFuture<Int> {
+        val query = """
+            |select count(*)
+            |from waystone_info
+            |where is_locked = true;
+        """.trimMargin()
+        return databaseManager
+            .query(query, rowMapper = CountRowMapper)
+            .thenApplyAsync { it ?: 0 }
+    }
+
     override fun mapRow(rs: ResultSet): WaystoneInfo = WaystoneInfo(
         worldUid = UUID.fromString(rs.getString("world_uid")),
         x = rs.getInt("x"),
         y = rs.getInt("y"),
         z = rs.getInt("z"),
         name = rs.getString("name"),
+        waystoneUuid = rs.getString("waystone_uuid")?.let(UUID::fromString),
+        primaryOwnerUuid = rs.getString("primary_owner_uuid")?.let(UUID::fromString),
+        isLocked = rs.getBoolean("is_locked"),
     )
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -20,6 +20,8 @@ enable-key-items: true
 enable-advancements: true
 show-compass-coordinates: true
 safe-liquids: WATER
+# Waystone locking mode: ALL, PER_WAYSTONE, or NONE
+waystone-locking: NONE
 key-recipe:
   - AIR
   - IRON_INGOT

--- a/src/main/resources/db/migration/common/V20260618120000__add_ownership_to_waystone_info.sql
+++ b/src/main/resources/db/migration/common/V20260618120000__add_ownership_to_waystone_info.sql
@@ -1,0 +1,15 @@
+-- Add ownership columns to waystone_info
+ALTER TABLE waystone_info ADD COLUMN waystone_uuid CHAR(36);
+ALTER TABLE waystone_info ADD COLUMN primary_owner_uuid CHAR(36);
+ALTER TABLE waystone_info ADD COLUMN is_locked BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Create unique index for waystone_uuid
+CREATE UNIQUE INDEX idx_waystone_info_waystone_uuid ON waystone_info(waystone_uuid);
+
+-- Create the authorized users table
+CREATE TABLE IF NOT EXISTS waystone_authorized_users (
+    waystone_uuid CHAR(36) NOT NULL,
+    owner_uuid CHAR(36) NOT NULL,
+    PRIMARY KEY (waystone_uuid, owner_uuid),
+    FOREIGN KEY (waystone_uuid) REFERENCES waystone_info(waystone_uuid) ON DELETE CASCADE
+);

--- a/src/test/kotlin/xyz/atrius/waystones/repository/WaystoneAuthorizedUsersRepositoryTest.kt
+++ b/src/test/kotlin/xyz/atrius/waystones/repository/WaystoneAuthorizedUsersRepositoryTest.kt
@@ -1,0 +1,73 @@
+package xyz.atrius.waystones.repository
+
+import io.kotest.assertions.assertSoftly
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import xyz.atrius.waystones.test.ServerFunSpec
+import java.util.UUID
+
+class WaystoneAuthorizedUsersRepositoryTest : ServerFunSpec({
+
+    val repository by lazy { get<WaystoneAuthorizedUsersRepository>() }
+
+    test("add and check authorized user") {
+        val waystoneId = UUID.randomUUID()
+        val playerUuid = UUID.randomUUID()
+
+        repository.addAuthorized(waystoneId, playerUuid).get().shouldBeTrue()
+        repository.isAuthorized(waystoneId, playerUuid).get().shouldBeTrue()
+    }
+
+    test("isAuthorized returns false for non-authorized user") {
+        val waystoneId = UUID.randomUUID()
+        val playerUuid = UUID.randomUUID()
+
+        repository.isAuthorized(waystoneId, playerUuid).get().shouldBeFalse()
+    }
+
+    test("remove authorized user") {
+        val waystoneId = UUID.randomUUID()
+        val playerUuid = UUID.randomUUID()
+
+        repository.addAuthorized(waystoneId, playerUuid).get()
+        repository.removeAuthorized(waystoneId, playerUuid).get().shouldBeTrue()
+        repository.isAuthorized(waystoneId, playerUuid).get().shouldBeFalse()
+    }
+
+    test("getAuthorized returns all authorized users") {
+        val waystoneId = UUID.randomUUID()
+        val player1 = UUID.randomUUID()
+        val player2 = UUID.randomUUID()
+
+        repository.addAuthorized(waystoneId, player1).get()
+        repository.addAuthorized(waystoneId, player2).get()
+
+        val authorized = repository.getAuthorized(waystoneId).get()
+        assertSoftly {
+            authorized shouldHaveSize 2
+            authorized.map { it.ownerUuid } shouldContain player1
+            authorized.map { it.ownerUuid } shouldContain player2
+        }
+    }
+
+    test("getAuthorized returns empty list for waystone with no authorized users") {
+        val waystoneId = UUID.randomUUID()
+
+        repository.getAuthorized(waystoneId).get().shouldBeEmpty()
+    }
+
+    test("addAuthorized is idempotent") {
+        val waystoneId = UUID.randomUUID()
+        val playerUuid = UUID.randomUUID()
+
+        repository.addAuthorized(waystoneId, playerUuid).get()
+        repository.addAuthorized(waystoneId, playerUuid).get().shouldBeFalse()
+
+        repository.isAuthorized(waystoneId, playerUuid).get().shouldBeTrue()
+        repository.getAuthorized(waystoneId).get() shouldHaveSize 1
+    }
+})

--- a/src/test/kotlin/xyz/atrius/waystones/repository/WaystoneInfoRepositoryTest.kt
+++ b/src/test/kotlin/xyz/atrius/waystones/repository/WaystoneInfoRepositoryTest.kt
@@ -1,0 +1,83 @@
+package xyz.atrius.waystones.repository
+
+import io.kotest.assertions.assertSoftly
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import xyz.atrius.waystones.test.ServerFunSpec
+import xyz.atrius.waystones.test.fixtures.WaystoneInfoFixtures.location
+import xyz.atrius.waystones.test.fixtures.WaystoneInfoFixtures.locked
+import xyz.atrius.waystones.test.fixtures.WaystoneInfoFixtures.unowned
+import xyz.atrius.waystones.test.fixtures.WaystoneInfoFixtures.waystone
+import java.util.UUID
+
+class WaystoneInfoRepositoryTest : ServerFunSpec({
+
+    val repository by lazy { get<WaystoneInfoRepository>() }
+
+    test("save and retrieve waystone by location") {
+        val loc = location(world, x = 100, y = 64, z = 200)
+        val expected = waystone(world, x = 100, y = 64, z = 200, name = "Test Waystone")
+
+        repository.save(expected).get() shouldBe 1
+
+        repository.getWaystone(loc).get().shouldNotBeNull {
+            assertSoftly {
+                name shouldBe "Test Waystone"
+                waystoneUuid shouldBe expected.waystoneUuid
+                primaryOwnerUuid shouldBe expected.primaryOwnerUuid
+                isLocked.shouldBeFalse()
+            }
+        }
+    }
+
+    test("save waystone with null waystoneUuid keeps null") {
+        val loc = location(world, x = 101, y = 64, z = 200)
+        val expected = unowned(world, x = 101, y = 64, z = 200)
+
+        repository.save(expected).get() shouldBe 1
+
+        repository.getWaystone(loc).get().shouldNotBeNull {
+            waystoneUuid.shouldBeNull()
+            name shouldBe "Unowned Waystone"
+        }
+    }
+
+    test("existsByLocation returns true for existing waystone") {
+        val loc = location(world, x = 102, y = 64, z = 200)
+        repository.save(waystone(world, x = 102, y = 64, z = 200)).get()
+
+        repository.existsByLocation(loc).get().shouldBeTrue()
+    }
+
+    test("existsByLocation returns false for non-existing waystone") {
+        val loc = location(world, x = 999, y = 64, z = 999)
+
+        repository.existsByLocation(loc).get().shouldBeFalse()
+    }
+
+    test("getLockedCount returns correct count") {
+        repository.save(locked(world, x = 104, y = 64, z = 200)).get()
+        repository.save(
+            waystone(world, x = 105, y = 64, z = 200, name = "Unlocked", isLocked = false)
+        ).get()
+
+        repository.getLockedCount().get() shouldBeGreaterThanOrEqual 1
+    }
+
+    test("save overwrites existing waystone at same location") {
+        val loc = location(world, x = 106, y = 64, z = 200)
+        val first = waystone(world, x = 106, y = 64, z = 200, name = "First")
+        val second = waystone(world, x = 106, y = 64, z = 200, name = "Second")
+
+        repository.save(first).get() shouldBe 1
+        repository.save(second).get() shouldBe 1
+
+        repository.getWaystone(loc).get().shouldNotBeNull {
+            name shouldBe "Second"
+        }
+    }
+})

--- a/src/test/kotlin/xyz/atrius/waystones/test/ServerFunSpec.kt
+++ b/src/test/kotlin/xyz/atrius/waystones/test/ServerFunSpec.kt
@@ -25,18 +25,6 @@ import xyz.atrius.waystones.Waystones
  * - The Waystones plugin loaded with full Koin DI
  * - A temporary SQLite database (auto-cleaned)
  * - Access to all plugin services via Koin
- *
- * Usage:
- * ```
- * class MyTest : ServerFunSpec({
- *     test("something works") {
- *         val player = createPlayer()
- *         val world = createWorld()
- *         val waystone = placeWaystone(world)
- *         // ... assertions
- *     }
- * })
- * ```
  */
 abstract class ServerFunSpec private constructor() : FunSpec() {
 
@@ -96,7 +84,6 @@ abstract class ServerFunSpec private constructor() : FunSpec() {
         y: Int = 64,
         z: Int = 0,
     ): Location = Location(world, x.toDouble(), y.toDouble(), z.toDouble())
-
 
     /** Place a block at the given coordinates. */
     internal fun placeBlock(

--- a/src/test/kotlin/xyz/atrius/waystones/test/fixtures/WaystoneInfoFixtures.kt
+++ b/src/test/kotlin/xyz/atrius/waystones/test/fixtures/WaystoneInfoFixtures.kt
@@ -1,0 +1,73 @@
+package xyz.atrius.waystones.test.fixtures
+
+import org.bukkit.Location
+import org.bukkit.World
+import xyz.atrius.waystones.dao.WaystoneInfo
+import java.util.UUID
+
+/**
+ * Factory methods for creating test [WaystoneInfo] instances.
+ *
+ * All parameters have sensible defaults so callers only need to specify
+ * the values relevant to their test case.
+ */
+object WaystoneInfoFixtures {
+
+    fun waystone(
+        world: World,
+        x: Int = 0,
+        y: Int = 64,
+        z: Int = 0,
+        name: String? = "Test Waystone",
+        waystoneUuid: UUID? = UUID.randomUUID(),
+        primaryOwnerUuid: UUID? = UUID.randomUUID(),
+        isLocked: Boolean = false,
+    ): WaystoneInfo = WaystoneInfo(
+        worldUid = world.uid,
+        x = x,
+        y = y,
+        z = z,
+        name = name,
+        waystoneUuid = waystoneUuid,
+        primaryOwnerUuid = primaryOwnerUuid,
+        isLocked = isLocked,
+    )
+
+    fun locked(
+        world: World,
+        x: Int = 0,
+        y: Int = 64,
+        z: Int = 0,
+        ownerUuid: UUID = UUID.randomUUID(),
+    ): WaystoneInfo = waystone(
+        world = world,
+        x = x,
+        y = y,
+        z = z,
+        name = "Locked Waystone",
+        primaryOwnerUuid = ownerUuid,
+        isLocked = true,
+    )
+
+    fun unowned(
+        world: World,
+        x: Int = 0,
+        y: Int = 64,
+        z: Int = 0,
+    ): WaystoneInfo = waystone(
+        world = world,
+        x = x,
+        y = y,
+        z = z,
+        name = "Unowned Waystone",
+        waystoneUuid = null,
+        primaryOwnerUuid = null,
+    )
+
+    fun location(
+        world: World,
+        x: Int = 0,
+        y: Int = 64,
+        z: Int = 0,
+    ): Location = Location(world, x.toDouble(), y.toDouble(), z.toDouble())
+}


### PR DESCRIPTION
This introduces the database schema and configuration for waystone ownership,
enabling players to lock waystones and control who can create link keys.

Schema changes:
- Add waystone_uuid, primary_owner_uuid, and is_locked columns to waystone_info
- Create waystone_authorized_users table for per-waystone authorization
- Add unique index on waystone_uuid

Application-side UUID generation and validation is handled via
WaystoneInfo.fromLocation() and UUID.fromString() in repositories.